### PR TITLE
Ignore invalid URLs that cause urljoin to raise.

### DIFF
--- a/test/invalid_link.html
+++ b/test/invalid_link.html
@@ -1,0 +1,1 @@
+<a href="http://example.com]path">The typo in the link here causes urljoin to raise.</a>

--- a/test/invalid_link.md
+++ b/test/invalid_link.md
@@ -1,0 +1,2 @@
+[The typo in the link here causes urljoin to raise.](http://example.com\]path)
+


### PR DESCRIPTION
This just copies the invalid URL into the markdown link verbatim instead of trying to join it to the base URL.